### PR TITLE
Update crate for Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/brentongunning/rust-sv"
 authors = ["Brenton Gunning <brentongunning@gmail.com>"]
 keywords = ["bitcoin", "sv", "cash", "crypto"]
 license = "MIT"
+edition = "2018"
 
 [dependencies]
 byteorder = "1.2"

--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -23,9 +23,9 @@
 //! let addr = addr_encode(&pubkeyhash, AddressType::P2PKH, Network::Mainnet);
 //! ```
 //! 
-use network::Network;
+use crate::network::Network;
 use rust_base58::base58::{FromBase58, ToBase58};
-use util::{sha256d, Error, Hash160, Result};
+use crate::util::{sha256d, Error, Hash160, Result};
 
 /// Address type which is either P2PKH or P2SH
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -97,7 +97,7 @@ pub fn addr_decode(input: &str, network: Network) -> Result<(Hash160, AddressTyp
 mod tests {
     use super::*;
     use hex;
-    use util::hash160;
+    use crate::util::hash160;
 
     #[test]
     fn to_addr() {

--- a/src/messages/addr.rs
+++ b/src/messages/addr.rs
@@ -1,9 +1,9 @@
-use messages::message::Payload;
-use messages::node_addr_ex::NodeAddrEx;
+use crate::messages::message::Payload;
+use crate::messages::node_addr_ex::NodeAddrEx;
 use std::fmt;
 use std::io;
 use std::io::{Read, Write};
-use util::{var_int, Error, Result, Serializable};
+use crate::util::{var_int, Error, Result, Serializable};
 
 /// Maximum number of addresses allowed in an Addr message
 const MAX_ADDR_COUNT: u64 = 1000;
@@ -59,7 +59,7 @@ impl fmt::Debug for Addr {
 mod tests {
     use super::*;
     use hex;
-    use messages::NodeAddr;
+    use crate::messages::NodeAddr;
     use std::io::Cursor;
     use std::net::Ipv6Addr;
 

--- a/src/messages/block.rs
+++ b/src/messages/block.rs
@@ -1,10 +1,10 @@
 use linked_hash_map::LinkedHashMap;
-use messages::{BlockHeader, OutPoint, Payload, Tx, TxOut};
+use crate::messages::{BlockHeader, OutPoint, Payload, Tx, TxOut};
 use std::collections::{HashSet, VecDeque};
 use std::fmt;
 use std::io;
 use std::io::{Read, Write};
-use util::{sha256d, var_int, Error, Hash256, Result, Serializable};
+use crate::util::{sha256d, var_int, Error, Hash256, Result, Serializable};
 
 /// Block height that Bitcoin Cash forked from BTC
 pub const BITCOIN_CASH_FORK_HEIGHT: i32 = 478558;
@@ -159,10 +159,10 @@ impl fmt::Debug for Block {
 mod tests {
     use super::*;
     use hex;
-    use messages::{OutPoint, TxIn, TxOut};
-    use script::Script;
+    use crate::messages::{OutPoint, TxIn, TxOut};
+    use crate::script::Script;
     use std::io::Cursor;
-    use util::{Amount, Hash256};
+    use crate::util::{Amount, Hash256};
 
     #[test]
     fn read_bytes() {

--- a/src/messages/block_header.rs
+++ b/src/messages/block_header.rs
@@ -2,7 +2,7 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::cmp::min;
 use std::io;
 use std::io::{Read, Write};
-use util::{sha256d, Error, Hash256, Result, Serializable};
+use crate::util::{sha256d, Error, Hash256, Result, Serializable};
 
 /// Block header
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]

--- a/src/messages/block_locator.rs
+++ b/src/messages/block_locator.rs
@@ -1,9 +1,9 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use messages::message::Payload;
-use messages::version::MIN_SUPPORTED_PROTOCOL_VERSION;
+use crate::messages::message::Payload;
+use crate::messages::version::MIN_SUPPORTED_PROTOCOL_VERSION;
 use std::io;
 use std::io::{Read, Write};
-use util::{var_int, Error, Hash256, Result, Serializable};
+use crate::util::{var_int, Error, Hash256, Result, Serializable};
 
 /// Return results until either there are 2000 for getheaders or 500 or getblocks, or no more left
 pub const NO_HASH_STOP: Hash256 = Hash256([0; 32]);

--- a/src/messages/fee_filter.rs
+++ b/src/messages/fee_filter.rs
@@ -1,8 +1,8 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use messages::message::Payload;
+use crate::messages::message::Payload;
 use std::io;
 use std::io::{Read, Write};
-use util::{Result, Serializable};
+use crate::util::{Result, Serializable};
 
 /// Specifies the minimum transaction fee this node accepts
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]

--- a/src/messages/filter_add.rs
+++ b/src/messages/filter_add.rs
@@ -1,9 +1,9 @@
 use hex;
-use messages::message::Payload;
+use crate::messages::message::Payload;
 use std::fmt;
 use std::io;
 use std::io::{Read, Write};
-use util::{var_int, Error, Result, Serializable};
+use crate::util::{var_int, Error, Result, Serializable};
 
 /// Maximum size of a data element in the FilterAdd message
 pub const MAX_FILTER_ADD_DATA_SIZE: usize = 520;

--- a/src/messages/filter_load.rs
+++ b/src/messages/filter_load.rs
@@ -1,8 +1,8 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use messages::message::Payload;
+use crate::messages::message::Payload;
 use std::io;
 use std::io::{Read, Write};
-use util::{var_int, BloomFilter, Result, Serializable};
+use crate::util::{var_int, BloomFilter, Result, Serializable};
 
 /// Filter is not adjusted when a match is found
 pub const BLOOM_UPDATE_NONE: u8 = 0;

--- a/src/messages/headers.rs
+++ b/src/messages/headers.rs
@@ -1,10 +1,10 @@
 use byteorder::{ReadBytesExt, WriteBytesExt};
-use messages::block_header::BlockHeader;
-use messages::message::Payload;
+use crate::messages::block_header::BlockHeader;
+use crate::messages::message::Payload;
 use std::fmt;
 use std::io;
 use std::io::{Read, Write};
-use util::{var_int, Error, Hash256, Result, Serializable};
+use crate::util::{var_int, Error, Hash256, Result, Serializable};
 
 /// Collection of block headers
 #[derive(Default, PartialEq, Eq, Hash, Clone)]
@@ -62,7 +62,7 @@ pub fn header_hash(i: usize, headers: &Vec<BlockHeader>) -> Result<Hash256> {
 mod tests {
     use super::*;
     use std::io::Cursor;
-    use util::Hash256;
+    use crate::util::Hash256;
 
     #[test]
     fn write_read() {

--- a/src/messages/inv.rs
+++ b/src/messages/inv.rs
@@ -1,9 +1,9 @@
-use messages::inv_vect::InvVect;
-use messages::message::Payload;
+use crate::messages::inv_vect::InvVect;
+use crate::messages::message::Payload;
 use std::fmt;
 use std::io;
 use std::io::{Read, Write};
-use util::{var_int, Error, Result, Serializable};
+use crate::util::{var_int, Error, Result, Serializable};
 
 /// Maximum number of objects in an inv message
 pub const MAX_INV_ENTRIES: usize = 50000;
@@ -60,9 +60,9 @@ impl fmt::Debug for Inv {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use messages::inv_vect::{INV_VECT_BLOCK, INV_VECT_TX};
+    use crate::messages::inv_vect::{INV_VECT_BLOCK, INV_VECT_TX};
     use std::io::Cursor;
-    use util::Hash256;
+    use crate::util::Hash256;
 
     #[test]
     fn write_read() {

--- a/src/messages/inv_vect.rs
+++ b/src/messages/inv_vect.rs
@@ -1,7 +1,7 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::io;
 use std::io::{Read, Write};
-use util::{Hash256, Result, Serializable};
+use crate::util::{Hash256, Result, Serializable};
 
 // Inventory vector types
 

--- a/src/messages/merkle_block.rs
+++ b/src/messages/merkle_block.rs
@@ -1,11 +1,11 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use hex;
-use messages::block_header::BlockHeader;
-use messages::message::Payload;
+use crate::messages::block_header::BlockHeader;
+use crate::messages::message::Payload;
 use std::fmt;
 use std::io;
 use std::io::{Read, Write};
-use util::{sha256d, var_int, Error, Hash256, Result, Serializable};
+use crate::util::{sha256d, var_int, Error, Hash256, Result, Serializable};
 
 /// A block header and partial merkle tree for SPV nodes to validate transactions
 #[derive(Default, PartialEq, Eq, Hash, Clone)]

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -1,23 +1,23 @@
-use messages::addr::Addr;
-use messages::block::Block;
-use messages::block_locator::BlockLocator;
-use messages::fee_filter::FeeFilter;
-use messages::filter_add::FilterAdd;
-use messages::filter_load::FilterLoad;
-use messages::headers::Headers;
-use messages::inv::Inv;
-use messages::merkle_block::MerkleBlock;
-use messages::message_header::MessageHeader;
-use messages::ping::Ping;
-use messages::reject::Reject;
-use messages::send_cmpct::SendCmpct;
-use messages::tx::Tx;
-use messages::version::Version;
+use crate::messages::addr::Addr;
+use crate::messages::block::Block;
+use crate::messages::block_locator::BlockLocator;
+use crate::messages::fee_filter::FeeFilter;
+use crate::messages::filter_add::FilterAdd;
+use crate::messages::filter_load::FilterLoad;
+use crate::messages::headers::Headers;
+use crate::messages::inv::Inv;
+use crate::messages::merkle_block::MerkleBlock;
+use crate::messages::message_header::MessageHeader;
+use crate::messages::ping::Ping;
+use crate::messages::reject::Reject;
+use crate::messages::send_cmpct::SendCmpct;
+use crate::messages::tx::Tx;
+use crate::messages::version::Version;
 use ring::digest;
 use std::fmt;
 use std::io;
 use std::io::{Cursor, Read, Write};
-use util::{Error, Result, Serializable};
+use crate::util::{Error, Result, Serializable};
 
 /// Checksum to use when there is an empty payload
 pub const NO_CHECKSUM: [u8; 4] = [0x5d, 0xf6, 0xe0, 0xe2];
@@ -468,20 +468,20 @@ pub trait Payload<T>: Serializable<T> + fmt::Debug {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use messages::block_header::BlockHeader;
-    use messages::inv_vect::{InvVect, INV_VECT_TX};
-    use messages::node_addr::NodeAddr;
-    use messages::node_addr_ex::NodeAddrEx;
-    use messages::out_point::OutPoint;
-    use messages::tx_in::TxIn;
-    use messages::tx_out::TxOut;
-    use messages::version::MIN_SUPPORTED_PROTOCOL_VERSION;
-    use messages::REJECT_INVALID;
-    use script::Script;
+    use crate::messages::block_header::BlockHeader;
+    use crate::messages::inv_vect::{InvVect, INV_VECT_TX};
+    use crate::messages::node_addr::NodeAddr;
+    use crate::messages::node_addr_ex::NodeAddrEx;
+    use crate::messages::out_point::OutPoint;
+    use crate::messages::tx_in::TxIn;
+    use crate::messages::tx_out::TxOut;
+    use crate::messages::version::MIN_SUPPORTED_PROTOCOL_VERSION;
+    use crate::messages::REJECT_INVALID;
+    use crate::script::Script;
     use std::io::Cursor;
     use std::net::Ipv6Addr;
     use std::time::UNIX_EPOCH;
-    use util::{secs_since, Amount, BloomFilter, Hash256};
+    use crate::util::{secs_since, Amount, BloomFilter, Hash256};
 
     #[test]
     fn write_read() {

--- a/src/messages/message_header.rs
+++ b/src/messages/message_header.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::io;
 use std::io::{Cursor, Read, Write};
 use std::str;
-use util::{Error, Result, Serializable};
+use crate::util::{Error, Result, Serializable};
 
 /// Header that begins all messages
 #[derive(Default, PartialEq, Eq, Hash, Clone)]

--- a/src/messages/node_addr.rs
+++ b/src/messages/node_addr.rs
@@ -2,7 +2,7 @@ use byteorder::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::io;
 use std::io::{Read, Write};
 use std::net::{IpAddr, Ipv6Addr};
-use util::{Result, Serializable};
+use crate::util::{Result, Serializable};
 
 /// Network address for a node on the network
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]

--- a/src/messages/node_addr_ex.rs
+++ b/src/messages/node_addr_ex.rs
@@ -1,8 +1,8 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use messages::node_addr::NodeAddr;
+use crate::messages::node_addr::NodeAddr;
 use std::io;
 use std::io::{Read, Write};
-use util::{Result, Serializable};
+use crate::util::{Result, Serializable};
 
 /// Node network address extended with a last connected time
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]

--- a/src/messages/out_point.rs
+++ b/src/messages/out_point.rs
@@ -1,7 +1,7 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::io;
 use std::io::{Read, Write};
-use util::{Hash256, Result, Serializable};
+use crate::util::{Hash256, Result, Serializable};
 
 /// The coinbase transaction input will have this hash
 pub const COINBASE_OUTPOINT_HASH: Hash256 = Hash256([0; 32]);

--- a/src/messages/ping.rs
+++ b/src/messages/ping.rs
@@ -1,8 +1,8 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use messages::message::Payload;
+use crate::messages::message::Payload;
 use std::io;
 use std::io::{Read, Write};
-use util::{Result, Serializable};
+use crate::util::{Result, Serializable};
 
 /// Ping or pong payload
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]

--- a/src/messages/reject.rs
+++ b/src/messages/reject.rs
@@ -1,9 +1,9 @@
 use byteorder::{ReadBytesExt, WriteBytesExt};
-use messages::message::Payload;
+use crate::messages::message::Payload;
 use std::fmt;
 use std::io;
 use std::io::{Cursor, Read, Write};
-use util::{var_int, Error, Hash256, Result, Serializable};
+use crate::util::{var_int, Error, Hash256, Result, Serializable};
 
 // Message rejection error codes
 pub const REJECT_MALFORMED: u8 = 0x01;

--- a/src/messages/send_cmpct.rs
+++ b/src/messages/send_cmpct.rs
@@ -1,8 +1,8 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use messages::message::Payload;
+use crate::messages::message::Payload;
 use std::io;
 use std::io::{Read, Write};
-use util::{Result, Serializable};
+use crate::util::{Result, Serializable};
 
 /// Specifies whether compact blocks are supported
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]

--- a/src/messages/tx.rs
+++ b/src/messages/tx.rs
@@ -1,13 +1,13 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use linked_hash_map::LinkedHashMap;
-use messages::message::Payload;
-use messages::{OutPoint, TxIn, TxOut, COINBASE_OUTPOINT_HASH, COINBASE_OUTPOINT_INDEX};
-use script::{op_codes, Script, TransactionChecker};
+use crate::messages::message::Payload;
+use crate::messages::{OutPoint, TxIn, TxOut, COINBASE_OUTPOINT_HASH, COINBASE_OUTPOINT_INDEX};
+use crate::script::{op_codes, Script, TransactionChecker};
 use std::fmt;
 use std::io;
 use std::io::{Read, Write};
-use transaction::sighash::SigHashCache;
-use util::{sha256d, var_int, Error, Hash256, Result, Serializable};
+use crate::transaction::sighash::SigHashCache;
+use crate::util::{sha256d, var_int, Error, Hash256, Result, Serializable};
 
 /// Maximum number of satoshis possible
 pub const MAX_SATOSHIS: i64 = 21_000_000 * 100_000_000;
@@ -210,9 +210,9 @@ impl fmt::Debug for Tx {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use messages::OutPoint;
+    use crate::messages::OutPoint;
     use std::io::Cursor;
-    use util::{Amount, Hash256};
+    use crate::util::{Amount, Hash256};
 
     #[test]
     fn write_read() {

--- a/src/messages/tx_in.rs
+++ b/src/messages/tx_in.rs
@@ -1,9 +1,9 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use messages::OutPoint;
-use script::Script;
+use crate::messages::OutPoint;
+use crate::script::Script;
 use std::io;
 use std::io::{Read, Write};
-use util::{var_int, Result, Serializable};
+use crate::util::{var_int, Result, Serializable};
 
 /// Transaction input
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
@@ -50,7 +50,7 @@ impl Serializable<TxIn> for TxIn {
 mod tests {
     use super::*;
     use std::io::Cursor;
-    use util::Hash256;
+    use crate::util::Hash256;
 
     #[test]
     fn write_read() {

--- a/src/messages/tx_out.rs
+++ b/src/messages/tx_out.rs
@@ -1,8 +1,8 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use script::Script;
+use crate::script::Script;
 use std::io;
 use std::io::{Read, Write};
-use util::{var_int, Amount, Result, Serializable};
+use crate::util::{var_int, Amount, Result, Serializable};
 
 /// Transaction output
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]

--- a/src/messages/version.rs
+++ b/src/messages/version.rs
@@ -1,10 +1,10 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use messages::message::Payload;
-use messages::node_addr::NodeAddr;
+use crate::messages::message::Payload;
+use crate::messages::node_addr::NodeAddr;
 use std::io;
 use std::io::{Read, Write};
 use std::time::UNIX_EPOCH;
-use util::{secs_since, var_int, Error, Result, Serializable};
+use crate::util::{secs_since, var_int, Error, Result, Serializable};
 
 /// Protocol version supported by this library
 pub const PROTOCOL_VERSION: u32 = 70015;

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -1,8 +1,8 @@
 use hex;
-use messages::{Block, BlockHeader, OutPoint, Tx, TxIn, TxOut};
-use network::SeedIter;
-use script::Script;
-use util::{Amount, Error, Hash256, Result};
+use crate::messages::{Block, BlockHeader, OutPoint, Tx, TxIn, TxOut};
+use crate::network::SeedIter;
+use crate::script::Script;
+use crate::util::{Amount, Error, Hash256, Result};
 
 /// Network type
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]

--- a/src/peer/peer.rs
+++ b/src/peer/peer.rs
@@ -1,6 +1,6 @@
-use messages::{Message, MessageHeader, Ping, Version, NODE_BITCOIN_CASH, NODE_NETWORK};
-use network::Network;
-use peer::atomic_reader::AtomicReader;
+use crate::messages::{Message, MessageHeader, Ping, Version, NODE_BITCOIN_CASH, NODE_NETWORK};
+use crate::network::Network;
+use crate::peer::atomic_reader::AtomicReader;
 use snowflake::ProcessUniqueId;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -11,8 +11,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::thread;
 use std::time::{Duration, UNIX_EPOCH};
-use util::rx::{Observable, Observer, Single, Subject};
-use util::{secs_since, Error, Result};
+use crate::util::rx::{Observable, Observer, Single, Subject};
+use crate::util::{secs_since, Error, Result};
 
 /// Time to wait for the initial TCP connection
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -41,7 +41,7 @@ pub struct PeerMessage {
 
 /// Filters peers based on their version information before connecting
 pub trait PeerFilter: Send + Sync {
-    fn connectable(&self, &Version) -> bool;
+    fn connectable(&self, _: &Version) -> bool;
 }
 
 /// Filters out all peers except for Bitcoin SV full nodes

--- a/src/script/checker.rs
+++ b/src/script/checker.rs
@@ -1,7 +1,7 @@
-use messages::Tx;
+use crate::messages::Tx;
 use secp256k1::{Message, PublicKey, Secp256k1, Signature};
-use transaction::sighash::{sighash, SigHashCache, SIGHASH_FORKID};
-use util::{Amount, Error, Result};
+use crate::transaction::sighash::{sighash, SigHashCache, SIGHASH_FORKID};
+use crate::util::{Amount, Error, Result};
 
 /// Locktimes greater than or equal to this are interpreted as timestamps. Less then, block heights.
 const LOCKTIME_THRESHOLD: i32 = 500000000;
@@ -137,15 +137,15 @@ impl<'a> Checker for TransactionChecker<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use messages::{OutPoint, TxIn, TxOut};
-    use script::op_codes::*;
-    use script::Script;
+    use crate::messages::{OutPoint, TxIn, TxOut};
+    use crate::script::op_codes::*;
+    use crate::script::Script;
     use secp256k1::{PublicKey, Secp256k1, SecretKey};
-    use transaction::generate_signature;
-    use transaction::sighash::{
+    use crate::transaction::generate_signature;
+    use crate::transaction::sighash::{
         SIGHASH_ALL, SIGHASH_ANYONECANPAY, SIGHASH_FORKID, SIGHASH_NONE, SIGHASH_SINGLE,
     };
-    use util::{hash160, Hash256};
+    use crate::util::{hash160, Hash256};
 
     #[test]
     fn standard_p2pkh() {

--- a/src/script/interpreter.rs
+++ b/src/script/interpreter.rs
@@ -1,13 +1,13 @@
 use digest::{FixedOutput, Input};
 use ring::digest::{digest, SHA1, SHA256};
 use ripemd160::{Digest, Ripemd160};
-use script::op_codes::*;
-use script::stack::{decode_bool, decode_num, encode_num, encode_num_overflow, pop_bool, pop_num};
-use script::{
+use crate::script::op_codes::*;
+use crate::script::stack::{decode_bool, decode_num, encode_num, encode_num_overflow, pop_bool, pop_num};
+use crate::script::{
     Checker, MAX_OPS_PER_SCRIPT, MAX_PUBKEYS_PER_MULTISIG, MAX_SCRIPT_ELEMENT_SIZE, MAX_SCRIPT_SIZE,
 };
-use transaction::sighash::SIGHASH_FORKID;
-use util::{hash160, lshift, rshift, sha256d, Error, Result};
+use crate::transaction::sighash::SIGHASH_FORKID;
+use crate::util::{hash160, lshift, rshift, sha256d, Error, Result};
 
 // Stack capacity defaults, which may exceeded
 const STACK_CAPACITY: usize = 100;
@@ -889,7 +889,7 @@ fn skip_branch(script: &[u8], mut i: usize, n_ops: &mut usize) -> usize {
 mod tests {
     use super::*;
     use hex;
-    use script::Script;
+    use crate::script::Script;
     use std::cell::RefCell;
 
     #[test]

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -17,9 +17,9 @@
 //! ```
 
 use hex;
-use script::op_codes::*;
+use crate::script::op_codes::*;
 use std::fmt;
-use util::Result;
+use crate::util::Result;
 
 mod checker;
 mod interpreter;

--- a/src/script/stack.rs
+++ b/src/script/stack.rs
@@ -1,4 +1,4 @@
-use util::{Error, Result};
+use crate::util::{Error, Result};
 
 /// Pops a bool off the stack
 #[inline]

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -30,7 +30,7 @@
 //! ```
 
 use secp256k1::{Message, Secp256k1, SecretKey};
-use util::{Hash256, Result};
+use crate::util::{Hash256, Result};
 
 pub mod p2pkh;
 pub mod sighash;

--- a/src/transaction/p2pkh.rs
+++ b/src/transaction/p2pkh.rs
@@ -1,8 +1,8 @@
 //! Pay-to-public-key-hash transaction scripts
 
-use script::op_codes::{OP_CHECKSIG, OP_DUP, OP_EQUALVERIFY, OP_HASH160, OP_PUSH};
-use script::{next_op, Script};
-use util::{Error, Hash160, Result};
+use crate::script::op_codes::{OP_CHECKSIG, OP_DUP, OP_EQUALVERIFY, OP_HASH160, OP_PUSH};
+use crate::script::{next_op, Script};
+use crate::util::{Error, Hash160, Result};
 
 /// Creates the pubkey script to send to an address
 pub fn create_pk_script(address: &Hash160) -> Script {
@@ -83,7 +83,7 @@ pub fn extract_pubkeyhash(pk_script: &[u8]) -> Result<Hash160> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use script::op_codes::OP_1;
+    use crate::script::op_codes::OP_1;
 
     #[test]
     fn check_pk_script_test() {

--- a/src/transaction/sighash.rs
+++ b/src/transaction/sighash.rs
@@ -1,10 +1,10 @@
 //! Transaction sighash helpers
 
 use byteorder::{LittleEndian, WriteBytesExt};
-use messages::{OutPoint, Payload, Tx, TxOut};
-use script::{next_op, op_codes, Script};
+use crate::messages::{OutPoint, Payload, Tx, TxOut};
+use crate::script::{next_op, op_codes, Script};
 use std::io::Write;
-use util::{sha256d, var_int, Amount, Error, Hash256, Result, Serializable};
+use crate::util::{sha256d, var_int, Amount, Error, Hash256, Result, Serializable};
 
 /// Signs all of the outputs
 pub const SIGHASH_ALL: u8 = 0x01;
@@ -252,11 +252,11 @@ fn legacy_sighash(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use address::addr_decode;
+    use crate::address::addr_decode;
     use hex;
-    use messages::{OutPoint, TxIn};
-    use network::Network;
-    use transaction::p2pkh;
+    use crate::messages::{OutPoint, TxIn};
+    use crate::network::Network;
+    use crate::transaction::p2pkh;
 
     #[test]
     fn bip143_sighash_test() {

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -1,7 +1,7 @@
 //! Functions to convert between different bitcoin denominations
 
 use std::fmt;
-use util::{Error, Result};
+use crate::util::{Error, Result};
 
 /// Denomination of a bitcoin amount
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]

--- a/src/util/bloom_filter.rs
+++ b/src/util/bloom_filter.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::io;
 use std::io::{Cursor, Read, Write};
 use std::num::Wrapping;
-use util::{var_int, Error, Result, Serializable};
+use crate::util::{var_int, Error, Result, Serializable};
 
 /// Maximum number of bytes in the bloom filter bit field
 pub const BLOOM_FILTER_MAX_FILTER_SIZE: usize = 36000;

--- a/src/util/future.rs
+++ b/src/util/future.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::mem::swap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use util::latch::Latch;
+use crate::util::latch::Latch;
 
 /// A promise for a value in the future
 pub struct Future<T> {

--- a/src/util/hash256.rs
+++ b/src/util/hash256.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::io;
 use std::io::{Read, Write};
-use util::{Error, Result, Serializable};
+use crate::util::{Error, Result, Serializable};
 
 /// 256-bit hash for blocks and transactions
 ///

--- a/src/util/latch.rs
+++ b/src/util/latch.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
-use util::{Error, Result};
+use crate::util::{Error, Result};
 
 /// A one-way latch for thread synchronization
 ///

--- a/src/util/rx.rs
+++ b/src/util/rx.rs
@@ -2,8 +2,8 @@
 
 use std::sync::{Arc, RwLock, TryLockError, Weak};
 use std::time::Duration;
-use util::future::{Future, FutureProvider};
-use util::{Error, Result};
+use crate::util::future::{Future, FutureProvider};
+use crate::util::{Error, Result};
 
 /// Observes an event of type T
 pub trait Observer<T>: Sync + Send {

--- a/src/util/serdes.rs
+++ b/src/util/serdes.rs
@@ -1,6 +1,6 @@
 use std::io;
 use std::io::{Read, Write};
-use util::Result;
+use crate::util::Result;
 
 /// An object that may be serialized and deserialized
 pub trait Serializable<T> {

--- a/src/wallet/extended_key.rs
+++ b/src/wallet/extended_key.rs
@@ -1,5 +1,5 @@
 use byteorder::{BigEndian, WriteBytesExt};
-use network::Network;
+use crate::network::Network;
 use ring::digest::SHA512;
 use ring::hmac;
 use rust_base58::base58::{FromBase58, ToBase58};
@@ -8,7 +8,7 @@ use std::fmt;
 use std::io;
 use std::io::{Cursor, Read, Write};
 use std::slice;
-use util::{hash160, sha256d, Error, Result, Serializable};
+use crate::util::{hash160, sha256d, Error, Result, Serializable};
 
 /// Maximum private key value (exclusive)
 const SECP256K1_CURVE_ORDER: [u8; 32] = [

--- a/src/wallet/mnemonic.rs
+++ b/src/wallet/mnemonic.rs
@@ -2,7 +2,7 @@
 
 use ring::digest::{digest, SHA256};
 use std::str;
-use util::{Bits, Error, Result};
+use crate::util::{Bits, Error, Result};
 
 /// Wordlist language
 pub enum Wordlist {


### PR DESCRIPTION
Run 'cargo fix --edition' to update crate for Rust 2018