### PR TITLE
nightly no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ Features
 
 Add ```sv = "0.1"``` to Cargo.toml
 
-# Requirements
-
-Rust nightly is required for documentation due to a bug fix which has not yet made it to stable.
-
-Run ./configure once to setup nightly.
-
 # Known limitations
 
 This library should not be used for consensus code because its validation checks are incomplete.

--- a/configure
+++ b/configure
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -e
-set -x
-
-rustup install nightly
-rustup update nightly
-rustup override set nightly


### PR DESCRIPTION
I've tested building the library and the documentation with rustc 1.36 stable without any problems.