### PR TITLE
Fix to enable downloading of 3.8GB blocks

### DIFF
--- a/src/peer/atomic_reader.rs
+++ b/src/peer/atomic_reader.rs
@@ -1,6 +1,8 @@
 use std::io;
 use std::io::Read;
 
+const MAX_BUFFER_SIZE_USIZE: usize = 2147483647;
+
 /// Wraps a reader so reads become all-or-nothing
 pub struct AtomicReader<'a> {
     buf: Vec<u8>,
@@ -26,7 +28,15 @@ impl<'a> Read for AtomicReader<'a> {
         } else if buf_len > 0 {
             // Copy what we have and try to read the rest
             out[0..buf_len].clone_from_slice(&self.buf[0..]);
-            let size = self.reader.read(&mut out[buf_len..])?;
+
+            // Check the size of this read
+            let size = if (out_len - buf_len) > MAX_BUFFER_SIZE_USIZE {
+                self.reader
+                    .read(&mut out[buf_len..buf_len + MAX_BUFFER_SIZE_USIZE])?
+            } else {
+                self.reader.read(&mut out[buf_len..])?
+            };
+
             if size == 0 {
                 Err(io::Error::new(io::ErrorKind::NotConnected, "Disconnected"))
             } else if buf_len + size < out_len {
@@ -39,7 +49,13 @@ impl<'a> Read for AtomicReader<'a> {
                 Ok(out_len)
             }
         } else {
-            let size = self.reader.read(&mut out[0..])?;
+            // Check the size of this read
+            let size = if out_len > MAX_BUFFER_SIZE_USIZE {
+                self.reader.read(&mut out[0..MAX_BUFFER_SIZE_USIZE])?
+            } else {
+                self.reader.read(&mut out[0..])?
+            };
+
             if size == 0 {
                 Err(io::Error::new(io::ErrorKind::NotConnected, "Disconnected"))
             } else if size < out_len {


### PR DESCRIPTION
The orignal AtomicReader would only read blocks upto 2GB. This is because the underlying posix read() function is limited to INT_MAX (+2147483647) as documented here https://www.ibm.com/docs/en/zos/2.1.0?topic=functions-read-read-from-file-socket

The update checks the size of the slice we are requesting if it is greater than MAX_BUFFER_SIZE_USIZE, then it limits the slice size to MAX_BUFFER_SIZE_USIZE. The remainder of the buffer will be requested on the next call to AtomicReader::read as intended.